### PR TITLE
Return null for ref 0

### DIFF
--- a/runtime/JniInterface.cs
+++ b/runtime/JniInterface.cs
@@ -19,7 +19,7 @@
 
   Jeroen Frijters
   jeroen@frijters.net
-  
+
 */
 using System;
 using System.Collections.Generic;
@@ -442,6 +442,10 @@ namespace IKVM.Runtime
 
 		internal static object Unwrap(int i)
 		{
+			if (i == 0)
+			{
+				return null;
+			}
 			i = -i;
 			if ((i & (1 << 30)) != 0)
 			{
@@ -594,7 +598,7 @@ namespace IKVM.Runtime
 			new pf_void(JNIEnv.ExceptionClear), //virtual void JNICALL ExceptionClear();
 			new pf_void_pbyte(JNIEnv.FatalError), //virtual void JNICALL FatalError(const char *msg);
 
-			new pf_int_int(JNIEnv.PushLocalFrame), //virtual jint JNICALL PushLocalFrame(jint capacity); 
+			new pf_int_int(JNIEnv.PushLocalFrame), //virtual jint JNICALL PushLocalFrame(jint capacity);
 			new pf_IntPtr_IntPtr(JNIEnv.PopLocalFrame), //virtual jobject JNICALL PopLocalFrame(jobject result);
 
 			new pf_IntPtr_IntPtr(JNIEnv.NewGlobalRef), //virtual jobject JNICALL NewGlobalRef(jobject lobj);
@@ -3347,7 +3351,7 @@ namespace IKVM.Runtime
 			finally
 			{
 				h.Free();
-			}		
+			}
 		}
 
 		internal static void ReleasePrimitiveArrayCritical(JNIEnv* pEnv, jarray array, void* carray, jint mode)
@@ -3406,7 +3410,7 @@ namespace IKVM.Runtime
 				{
 					*isCopy = JNI_TRUE;
 				}
-				return (jchar*)(void*)Marshal.StringToHGlobalUni(s);		
+				return (jchar*)(void*)Marshal.StringToHGlobalUni(s);
 			}
 			SetPendingException(pEnv, new java.lang.NullPointerException());
 			return null;
@@ -3497,7 +3501,7 @@ namespace IKVM.Runtime
 				return IntPtr.Zero;
 			}
 		}
-		
+
 		internal static jlong GetDirectBufferCapacity(JNIEnv* pEnv, jobject buf)
 		{
 			try


### PR DESCRIPTION
Rather than throw a exception due
to negative index
(keeping exception for other cases
since while NULL and 0 are usually
equivalent, other values should just
mean "uninitialized")

Change-Id: I82dfb0883df378134da980798a3c7a07252ce9b3